### PR TITLE
Use ng-admin as parent for states

### DIFF
--- a/js/module.js
+++ b/js/module.js
@@ -5,7 +5,7 @@ var ngAdminJWTAuth = angular.module('ng-admin.jwt-auth', ['angular-jwt']);
 ngAdminJWTAuth.config(['$stateProvider', '$httpProvider', function ($stateProvider, $httpProvider) {
 
 	$stateProvider.state('login', {
-		parent: '',
+		parent: 'ng-admin',
 		url: '/login',
 		controller: 'loginController',
 		controllerAs: 'loginController',
@@ -29,7 +29,7 @@ ngAdminJWTAuth.config(['$stateProvider', '$httpProvider', function ($stateProvid
 	});
 
 	$stateProvider.state('logout', {
-		parent: '',
+		parent: 'ng-admin',
 		url: '/logout',
 		controller: 'logoutController',
 		controllerAs: 'logoutController',


### PR DESCRIPTION
https://github.com/marmelab/ng-admin/pull/759 renamed the main view to `ng-admin`
This breaks ng-admin JWT-Auth with the latest ng-admin versions.